### PR TITLE
fix: Remove unneeded payload in GetAllCategories request

### DIFF
--- a/oneroster_1_1_test_suite.ipynb
+++ b/oneroster_1_1_test_suite.ipynb
@@ -1055,7 +1055,7 @@
       "source": [
         "url = f\"{config.one_roster_url}/categories?limit=10000\"\n",
         "\n",
-        "response = requests.request(\"GET\", url, headers=request_headers, data=payload)\n",
+        "response = requests.request(\"GET\", url, headers=request_headers)\n",
         "latency_report[\"GetAllCategories\"] = response.elapsed.microseconds / 1000\n",
         "data = response.json()\n",
         "\n",


### PR DESCRIPTION
[Fixes this issue](https://github.com/googleworkspace/oneroster-integration-conformance-tests/issues/7)